### PR TITLE
Fix nav active state for section links

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,8 @@
         color: var(--muted);
         transition: color 0.2s;
       }
-      .text-nav a:hover { color: var(--accent-2); }
+      .text-nav a:hover,
+      .text-nav a.active { color: var(--accent-2); }
 
       /* Divider between text nav and icon nav */
       .nav-divider {
@@ -588,5 +589,35 @@
     </div>
 
     <script src="assets/js/reveal.js"></script>
+    <script>
+      (() => {
+        const navLinks = document.querySelectorAll('.text-nav a[href^="#"]');
+        if (!navLinks.length) return;
+
+        const setActive = hash => {
+          navLinks.forEach(link => {
+            link.classList.toggle('active', link.getAttribute('href') === hash);
+          });
+        };
+
+        const updateFromHash = () => {
+          const { hash } = window.location;
+          if (!hash) {
+            navLinks.forEach(link => link.classList.remove('active'));
+            return;
+          }
+          setActive(hash);
+        };
+
+        navLinks.forEach(link => {
+          link.addEventListener('click', () => {
+            setActive(link.getAttribute('href'));
+          });
+        });
+
+        window.addEventListener('hashchange', updateFromHash);
+        updateFromHash();
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Section anchor links like `#triage` and `#projects` were not staying highlighted in the header after navigation, producing an inconsistent active state compared to the `Findings` link.

### Description
- Update the header styles so `.text-nav a.active` uses the same highlight as hover by changing the selector to `.text-nav a:hover, .text-nav a.active` in `index.html`.
- Add a small hash-aware script to `index.html` that toggles the `active` class for `.text-nav a[href^="#"]` on click and on `hashchange`, and initializes the state from `window.location.hash`.

### Testing
- Verified visually by starting a local server with `python -m http.server` and loading `index.html#triage` using a Playwright script which captured `artifacts/triage-nav-active.png`, confirming the `#triage` link is highlighted (succeeded).
- No additional automated unit tests were required for this static site change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69894cd994ac8323a923c73bc607127f)